### PR TITLE
Rename dig to dotted_dig

### DIFF
--- a/lib/buff/extensions/hash/dotted_paths.rb
+++ b/lib/buff/extensions/hash/dotted_paths.rb
@@ -79,12 +79,12 @@ module Buff
       #     }
       #   }
       #
-      #   nested_hash.dig('deep.nested.hash') => :seed_value
+      #   nested_hash.dotted_dig('deep.nested.hash') => :seed_value
       #
       # @param [String] path
       #
       # @return [Object, nil]
-      def dig(path)
+      def dotted_dig(path)
         return nil unless path.present?
 
         parts = path.split('.', 2)
@@ -92,7 +92,7 @@ module Buff
         if !parts[1] or match.nil?
           match
         else
-          match.dig(parts[1])
+          match.dotted_dig(parts[1])
         end
       end
 

--- a/spec/buff/extensions/hash/dotted_paths_spec.rb
+++ b/spec/buff/extensions/hash/dotted_paths_spec.rb
@@ -41,7 +41,7 @@ describe Buff::Extensions::Hash::DottedPaths do
 
   subject { Hash.new }
 
-  describe "#dig" do
+  describe "#dotted_dig" do
     context "when the Hash contains the nested path" do
       subject do
         {
@@ -54,13 +54,13 @@ describe Buff::Extensions::Hash::DottedPaths do
       end
 
       it "returns the value at the dotted path" do
-        expect(subject.dig("we.found.something")).to eql(true)
+        expect(subject.dotted_dig("we.found.something")).to eql(true)
       end
     end
 
     context "when the Hash does not contain the nested path" do
       it "returns a nil value" do
-        expect(subject.dig("nothing.is.here")).to be_nil
+        expect(subject.dotted_dig("nothing.is.here")).to be_nil
       end
     end
 
@@ -76,12 +76,12 @@ describe Buff::Extensions::Hash::DottedPaths do
       end
 
       it "returns the value at the dotted path" do
-        expect(subject.dig("we.found.something")).to eql(:symbol_value)
+        expect(subject.dotted_dig("we.found.something")).to eql(:symbol_value)
       end
     end
 
     it "returns nil if given a blank string" do
-      expect(subject.dig("")).to be_nil
+      expect(subject.dotted_dig("")).to be_nil
     end
 
     it "returns 'false' nested values as 'false' and not 'nil'" do
@@ -91,7 +91,7 @@ describe Buff::Extensions::Hash::DottedPaths do
         }
       }
 
-      expect(hash.dig('ssl.verify')).to eql(false)
+      expect(hash.dotted_dig('ssl.verify')).to eql(false)
     end
   end
 


### PR DESCRIPTION
This pull request renames `dig` to `dotted_dig` to avoid a collision with `Hash#dig` in ruby >= 2.3.0.

Fixes #6, and means that all tests pass on ruby 2.3

Since this is a change of the API, consumers of this library will need updating. But the change is straightforward to apply, and anything which uses this method is already broken on ruby 2.3, so I think it's definitely worth doing.
